### PR TITLE
Here's the revised message:

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -22,7 +22,7 @@ def load_wav(file_path, sample_rate=None):
 
 def save_wav(file_path, audio_data, sample_rate):
     try:
-        sf.write(file_path, audio_data, sample_rate)
+        sf.write(file_path, audio_data, sample_rate, format='WAV', subtype='FLOAT')
         return True
     except Exception as e:
         logger.error(f"Ошибка сохранения WAV файла {file_path}: {e}")


### PR DESCRIPTION
Исправить ошибку сохранения WAV при инференсе

В функции `save_wav` (src/data_loader.py) в вызов `sf.write` добавлено явное указание формата и подтипа:
`format='WAV'`, `subtype='FLOAT'`.

Это сделано для предотвращения ошибки "Format not recognised", которая возникала при сохранении аудиофайла на этапе инференса. Явное указание этих параметров помогает библиотеке `soundfile` корректно интерпретировать данные и формат сохранения.